### PR TITLE
Fix for shorter if let lifetime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,8 +151,9 @@ fn load_project_types() -> Result<HashMap<String, ProjectType>> {
 }
 
 fn get_config_path() -> Result<PathBuf> {
+    let project_dirs = ProjectDirs::from("", "HaNa", "project_manager");
     let mut config_path: PathBuf =
-        if let Some(project_dirs) = &ProjectDirs::from("", "HaNa", "project_manager") {
+        if let Some(project_dirs) = &project_dirs {
             Ok(project_dirs.config_dir())
         } else {
             Err(anyhow!("failed finding the config directory"))


### PR DESCRIPTION
Context: Rust compiler PR https://github.com/rust-lang/rust/pull/107251 wants to change the lifetime of things inside the `if let` matcher. The PR would break the build of this project (out of only a handful of breakages):

```Rust
error[E0716]: temporary value dropped while borrowed
   --> src/main.rs:155:38
    |
155 |           if let Some(project_dirs) = &ProjectDirs::from("", "HaNa", "project_manager") {
    |           -                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ creates a temporary value which is freed while still in use
    |  _________|
    | |
156 | |             Ok(project_dirs.config_dir())
157 | |         } else {
    | |         - temporary value is freed at the end of this statement
158 | |             Err(anyhow!("failed finding the config directory"))
159 | |         }?
    | |__________- borrow later used by call
    |
help: consider using a `let` binding to create a longer lived value
    |
154 ~     let binding = ProjectDirs::from("", "HaNa", "project_manager");
155 ~     let mut config_path: PathBuf =
156 ~         if let Some(project_dirs) = &binding {
    |
```

The new version compiles both before and after the PR.